### PR TITLE
Move all the recording stuff to a different (reusable) class.

### DIFF
--- a/RecordMyScreen.xcodeproj/project.pbxproj
+++ b/RecordMyScreen.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		38E6ECBE16ACA3FE000BECC2 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38E6ECBC16ACA3F9000BECC2 /* MessageUI.framework */; };
 		38E6ECC116ACB77D000BECC2 /* settings.png in Resources */ = {isa = PBXBuildFile; fileRef = 38E6ECBF16ACB77D000BECC2 /* settings.png */; };
 		38E6ECC216ACB77D000BECC2 /* settings@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 38E6ECC016ACB77D000BECC2 /* settings@2x.png */; };
+		48DC7016170A7F4700DE3765 /* CSScreenRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 48DC7015170A7F4700DE3765 /* CSScreenRecorder.m */; };
 		8ECF16F31697E07400DBA7D2 /* GraphicsServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ECF16F21697E07400DBA7D2 /* GraphicsServices.framework */; };
 		8ECF16F51697E0A000DBA7D2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8ECF16F41697E0A000DBA7D2 /* QuartzCore.framework */; };
 		DF80BC12169482EA00EA056A /* CSRecordViewController_iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = DF80BC11169482EA00EA056A /* CSRecordViewController_iPad.xib */; };
@@ -153,6 +154,8 @@
 		38E6ECBC16ACA3F9000BECC2 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		38E6ECBF16ACB77D000BECC2 /* settings.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = settings.png; sourceTree = "<group>"; };
 		38E6ECC016ACB77D000BECC2 /* settings@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "settings@2x.png"; sourceTree = "<group>"; };
+		48DC7014170A7F4700DE3765 /* CSScreenRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSScreenRecorder.h; sourceTree = "<group>"; };
+		48DC7015170A7F4700DE3765 /* CSScreenRecorder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSScreenRecorder.m; sourceTree = "<group>"; };
 		8ECF16F21697E07400DBA7D2 /* GraphicsServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GraphicsServices.framework; path = System/Library/PrivateFrameworks/GraphicsServices.framework; sourceTree = SDKROOT; };
 		8ECF16F41697E0A000DBA7D2 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		DF80BC11169482EA00EA056A /* CSRecordViewController_iPad.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CSRecordViewController_iPad.xib; sourceTree = "<group>"; };
@@ -289,6 +292,7 @@
 		389BCCFF169010CF00877CA5 /* RecordMyScreen */ = {
 			isa = PBXGroup;
 			children = (
+				48DC7017170A7F4B00DE3765 /* CSScreenRecorder */,
 				389BCD2A169010FB00877CA5 /* CSRecordViewController */,
 				382758E41690E0A7000D537C /* CSRecordingListController */,
 				3800B56C16D1DAAA0034E4B4 /* CSCreditsViewController */,
@@ -402,6 +406,15 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		48DC7017170A7F4B00DE3765 /* CSScreenRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				48DC7014170A7F4700DE3765 /* CSScreenRecorder.h */,
+				48DC7015170A7F4700DE3765 /* CSScreenRecorder.m */,
+			);
+			name = CSScreenRecorder;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -507,6 +520,7 @@
 				38E6ECBA16ACA3CB000BECC2 /* IASKSwitch.m in Sources */,
 				38E6ECBB16ACA3CB000BECC2 /* IASKTextField.m in Sources */,
 				3800B57016D1DACC0034E4B4 /* CSCreditsViewController.m in Sources */,
+				48DC7016170A7F4700DE3765 /* CSScreenRecorder.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,7 +545,8 @@
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Dylan Laws (5PG53H8462)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Dylan Laws (5PG53H8462)";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = "$(SDK_DIR)/System/Library/PrivateFrameworks";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -558,6 +573,8 @@
 					"-framework",
 					IOKit,
 				);
+				PROVISIONING_PROFILE = "EDD98B71-2A9F-401F-9C81-D887C3AEAD06";
+				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "EDD98B71-2A9F-401F-9C81-D887C3AEAD06";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -570,7 +587,8 @@
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "iPhone Developer: Dylan Laws (5PG53H8462)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer: Dylan Laws (5PG53H8462)";
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(SDK_DIR)/System/Library/PrivateFrameworks";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -591,6 +609,8 @@
 					"-framework",
 					IOKit,
 				);
+				PROVISIONING_PROFILE = "EDD98B71-2A9F-401F-9C81-D887C3AEAD06";
+				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "EDD98B71-2A9F-401F-9C81-D887C3AEAD06";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -609,7 +629,7 @@
 				INFOPLIST_FILE = "RecordMyScreen/RecordMyScreen-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos6.0;
+				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -626,7 +646,7 @@
 				INFOPLIST_FILE = "RecordMyScreen/RecordMyScreen-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos6.0;
+				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/RecordMyScreen/CSRecordViewController.h
+++ b/RecordMyScreen/CSRecordViewController.h
@@ -8,38 +8,16 @@
 
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
-#import <IOSurface.h>
 
-@interface CSRecordViewController : UIViewController <AVAudioRecorderDelegate> {
-    bool _isRecording;
-    UISegmentedControl *_record,*_stop;
-    IBOutlet UIImageView *_recordbar;
-    IBOutlet UILabel *_statusLabel;
+#import "CSScreenRecorder.h"
+
+
+@interface CSRecordViewController : UIViewController <CSScreenRecorderDelegate>
+{
+    UISegmentedControl      *_record, *_stop;
+    IBOutlet UIImageView    *_recordbar;
+    IBOutlet UILabel        *_statusLabel;
     IBOutlet UIProgressView *_progressView;
-    NSTimer *_recordingTimer;
-    NSDate *_recordStartDate;
-    AVAudioRecorder *_audioRecorder;
-    
-    //surface
-    IOSurfaceRef _surface;
-    int _bytesPerRow;
-    int _width;
-    int _height;
-    
-    
-    //video writing
-    dispatch_queue_t _video_queue;
-    int _kbps;
-    int _fps;
-    NSLock *_pixelBufferLock;
-    AVAssetWriter *_videoWriter;
-    AVAssetWriterInput *_videoWriterInput;
-    AVAssetWriterInputPixelBufferAdaptor *_pixelBufferAdaptor;
+
 }
-
-- (void)createScreenSurface;
-- (void)captureShot:(CMTime)frameTime;
-- (void)setupVideoContext;
 @end
-
-void CARenderServerRenderDisplay( kern_return_t a, CFStringRef b, IOSurfaceRef surface, int x, int y);

--- a/RecordMyScreen/CSRecordViewController.m
+++ b/RecordMyScreen/CSRecordViewController.m
@@ -11,26 +11,29 @@
 #include <sys/time.h>
 #import <CoreVideo/CVPixelBuffer.h>
 
+@interface CSRecordViewController ()
+{
+    CSScreenRecorder *_screenRecorder;
+}
+@end
+
 @implementation CSRecordViewController
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
+        _screenRecorder = [[CSScreenRecorder alloc] init];
+        _screenRecorder.delegate = self;
         self.tabBarItem = [[[UITabBarItem alloc] initWithTitle:NSLocalizedString(@"Record", @"") image:[UIImage imageNamed:@"video"] tag:0] autorelease];
-        _pixelBufferLock = [NSLock new];
-        
-        //video queue
-        _video_queue = dispatch_queue_create("video_queue", DISPATCH_QUEUE_SERIAL);
-        //frame rate
-        _fps = 24;
-        //encoding kbps
-        _kbps = 5000;
     }
     return self;
 }
--(void)dealloc {
-    dispatch_release(_video_queue);
-    CFRelease(_surface);
+
+- (void)dealloc
+{
+    [_screenRecorder release];
+    _screenRecorder = nil;
+    
     [super dealloc];
 }
 
@@ -82,134 +85,55 @@
 
 #pragma mark - Starting / Stopping
 
-- (void)record: (id)sender
+- (void)record:(id)sender
 {
+    // Update the UI
+    _statusLabel.text = @"00:00:00";
+    _stop.enabled = YES;
+    _record.enabled = NO;
+    
     // Remove the old video
     [[NSFileManager defaultManager] removeItemAtPath:[NSHomeDirectory() stringByAppendingPathComponent:@"Documents/video.mp4"] error:nil];
     
-    // if the AVAssetWriter is NOT valid, setup video context
-    if(!_videoWriter)
-        [self setupVideoContext];
-    
-    // Update the UI
-    _statusLabel.text = @"00:00:00";
-    _recordStartDate = [[NSDate date] retain];
-    _stop.enabled = YES;
-    _record.enabled = NO;
-	
-    // Setup to be able to record global sounds (preexisting app sounds)
-	NSError *sessionError = nil;
-    if ([[AVAudioSession sharedInstance] respondsToSelector:@selector(setCategory:withOptions:error:)])
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDuckOthers error:&sessionError];
-    else
-        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&sessionError];
-    
-    // Set the audio session to be active
-	[[AVAudioSession sharedInstance] setActive:YES error:&sessionError];
+    NSString *videoPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents/video.mp4"];
+    if (![[[NSUserDefaults standardUserDefaults] objectForKey:@"record"] boolValue]) {
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setDateFormat:@"MM:dd:yyyy h:mm:ss a"];
+        NSString *date = [dateFormatter stringFromDate:[NSDate date]];
+        NSString *outName = [NSString stringWithFormat:@"Documents/%@.mp4",date];
+        videoPath = [NSHomeDirectory() stringByAppendingPathComponent:outName];
+        [dateFormatter release];
+    }
     
     // Set the number of audio channels
     NSNumber *audioChannels = [[NSUserDefaults standardUserDefaults] objectForKey:@"channels"];
     NSNumber *sampleRate = [[NSUserDefaults standardUserDefaults] objectForKey:@"samplerate"];
-    NSDictionary *audioSettings = @{
-    AVNumberOfChannelsKey : audioChannels ? audioChannels : [NSNumber numberWithInt:2],
-    AVSampleRateKey : sampleRate ? sampleRate : [NSNumber numberWithFloat:44100.0f]
-    };
+    NSString *audioPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents/audio.caf"];
     
-    // Set output path of the audio file
-    NSError *error = nil;
-    NSString *path = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents/audio.caf"];
+    _screenRecorder.videoOutPath = videoPath;
+    _screenRecorder.audioOutPath = audioPath;
+    _screenRecorder.numberOfAudioChannels = audioChannels;
+    _screenRecorder.audioSampleRate = sampleRate;
     
-    // Initialize the audio recorder
-    _audioRecorder = [[AVAudioRecorder alloc] initWithURL:[NSURL fileURLWithPath:path] settings:audioSettings error:&error];
-    [_audioRecorder setDelegate:self];
-    [_audioRecorder prepareToRecord];
-    
-    // Start recording :P
-    [_audioRecorder record];
-    
-    // Set timer to update the record time label
-    _recordingTimer = [NSTimer scheduledTimerWithTimeInterval:1
-                                                       target:self
-                                                     selector:@selector(updateTimer:)
-                                                     userInfo:nil
-                                                      repeats:YES];
-    
-    _isRecording = TRUE;
-    
-    //capture loop (In another thread)
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        int targetFPS = _fps;
-        int msBeforeNextCapture = 1000 / targetFPS;
-        
-        struct timeval lastCapture, currentTime, startTime;
-        lastCapture.tv_sec = 0;
-        lastCapture.tv_usec = 0;
-        
-        //recording start time
-        gettimeofday(&startTime, NULL);
-        startTime.tv_usec /= 1000;
-        
-        int lastFrame = -1;
-        while(_isRecording)
-        {
-            //time passed since last capture
-            gettimeofday(&currentTime, NULL);
-            
-            //convert to milliseconds to avoid overflows
-            currentTime.tv_usec /= 1000;
-            
-            unsigned long long diff = (currentTime.tv_usec + (1000 * currentTime.tv_sec) ) - (lastCapture.tv_usec + (1000 * lastCapture.tv_sec) );
-            
-            // if enough time has passed, capture another shot
-            if(diff >= msBeforeNextCapture)
-            {
-                //time since start
-                long int msSinceStart = (currentTime.tv_usec + (1000 * currentTime.tv_sec) ) - (startTime.tv_usec + (1000 * startTime.tv_sec) );
-                
-                // Generate the frame number
-                int frameNumber = msSinceStart / msBeforeNextCapture;
-                CMTime presentTime;
-                presentTime = CMTimeMake(frameNumber, targetFPS);
-                
-                // Frame number cannot be last frames number :P
-                NSParameterAssert(frameNumber != lastFrame);
-                lastFrame = frameNumber;
-                
-                // Capture next shot and repeat
-                [self captureShot:presentTime];
-                lastCapture = currentTime;
-            }
-        }
-        
-        // finish encoding, using the video_queue thread
-        dispatch_async(_video_queue, ^{
-            [self finishEncoding];
-        });
-        
-    });
+    [_screenRecorder startRecordingScreen];
 }
 
-- (void)stop: (id)sender {
-    // Set the flag to stop recording
-    _isRecording = NO;
-    
+- (void)stop:(id)sender
+{
+    [_screenRecorder stopRecordingScreen];
+}
+
+- (void)screenRecorderDidStopRecording:(CSScreenRecorder *)recorder
+{
     // Disable the stop button
     _stop.enabled = NO;
-    
-    // Invalidate the recording time
-    [_recordingTimer invalidate];
-    _recordingTimer = nil;
     
     // Announce Encoding will begin
     _statusLabel.text = @"Encoding Movie...";
     
     // Show progress view
     _progressView.hidden = NO;
-    
-    // Stop the audio recording
-    [_audioRecorder stop];
-    [_audioRecorder release];
-    
+
     // Update the UI for another round
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
     dispatch_async(queue, ^{
@@ -219,21 +143,12 @@
             _record.enabled = YES;
         });
     });
-    
-    [_recordStartDate release];
-    _recordStartDate = nil;
-    _audioRecorder = nil;
 }
 
-- (void)updateTimer:(NSTimer *)timer {
-    // Get the current date
-    NSDate *currentDate = [NSDate date];
-    
-    // Current time
-    NSTimeInterval timeInterval = [currentDate timeIntervalSinceDate:_recordStartDate];
-    
-    // Get date from when the recording started
-    NSDate *timerDate = [NSDate dateWithTimeIntervalSince1970:timeInterval];
+- (void)screenRecorder:(CSScreenRecorder *)recorder recordingTimeChanged:(NSTimeInterval)recordingInterval
+{
+    // get an NSDate object from NSTimeInterval
+    NSDate *timerDate = [NSDate dateWithTimeIntervalSince1970:recordingInterval];
     
     // Make a date formatter (Possibly reuse instead of creating each time)
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
@@ -241,253 +156,25 @@
     [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0.0]];
     
     // Set the current time since recording began
-    NSString *timeString=[dateFormatter stringFromDate:timerDate];
+    NSString *timeString = [dateFormatter stringFromDate:timerDate];
     _statusLabel.text = timeString;
     [dateFormatter release];
 }
 
-#pragma mark - Capturing
-
-- (void)createScreenSurface
+// Stubs. Do Error handling shit here.
+- (void)screenRecorder:(CSScreenRecorder *)recorder videoContextSetupFailedWithError:(NSError *)error
 {
-    // Pixel format for Alpha Red Green Blue
-    unsigned pixelFormat = 0x42475241;//'ARGB';
-    
-    // 4 Bytes per pixel
-    int bytesPerElement = 4;
-    
-    // Bytes per row
-    _bytesPerRow = (bytesPerElement * _width);
-    
-    // Properties include: SurfaceIsGlobal, BytesPerElement, BytesPerRow, SurfaceWidth, SurfaceHeight, PixelFormat, SurfaceAllocSize (space for the entire surface)
-    NSDictionary *properties = [NSDictionary dictionaryWithObjectsAndKeys:
-                                [NSNumber numberWithBool:YES], kIOSurfaceIsGlobal,
-                                [NSNumber numberWithInt:bytesPerElement], kIOSurfaceBytesPerElement,
-                                [NSNumber numberWithInt:_bytesPerRow], kIOSurfaceBytesPerRow,
-                                [NSNumber numberWithInt:_width], kIOSurfaceWidth,
-                                [NSNumber numberWithInt:_height], kIOSurfaceHeight,
-                                [NSNumber numberWithUnsignedInt:pixelFormat], kIOSurfacePixelFormat,
-                                [NSNumber numberWithInt:_bytesPerRow * _height], kIOSurfaceAllocSize,
-                                nil];
-    
-    // This is the current surface
-    _surface = IOSurfaceCreate((CFDictionaryRef)properties);
-}
-
-- (void)captureShot:(CMTime)frameTime
-{
-    // Create an IOSurfaceRef if one does not exist
-    if(!_surface)
-        [self createScreenSurface];
-    
-    // Lock the surface from other threads
-    static NSMutableArray * buffers = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        buffers = [[NSMutableArray alloc] init];
-    });
-    
-    IOSurfaceLock(_surface, 0, nil);
-    // Take currently displayed image from the LCD
-    CARenderServerRenderDisplay(0, CFSTR("LCD"), _surface, 0, 0);
-    // Unlock the surface
-    IOSurfaceUnlock(_surface, 0, 0);
-    
-    // Make a raw memory copy of the surface
-    void *baseAddr = IOSurfaceGetBaseAddress(_surface);
-    int totalBytes = _bytesPerRow * _height;
-    
-    //void *rawData = malloc(totalBytes);
-    //memcpy(rawData, baseAddr, totalBytes);
-    NSMutableData * rawDataObj = nil;
-    if (buffers.count == 0)
-        rawDataObj = [[NSMutableData dataWithBytes:baseAddr length:totalBytes] retain];
-    else @synchronized(buffers) {
-        rawDataObj = [buffers lastObject];
-        memcpy((void *)[rawDataObj bytes], baseAddr, totalBytes);
-        //[rawDataObj replaceBytesInRange:NSMakeRange(0, rawDataObj.length) withBytes:baseAddr length:totalBytes];
-        [buffers removeLastObject];
-    }
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-        
-        if(!_pixelBufferAdaptor.pixelBufferPool){
-            NSLog(@"skipping frame: %lld", frameTime.value);
-            //free(rawData);
-            @synchronized(buffers) {
-                //[buffers addObject:rawDataObj];
-            }
-            return;
-        }
-        
-        static CVPixelBufferRef pixelBuffer = NULL;
-        
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            NSParameterAssert(_pixelBufferAdaptor.pixelBufferPool != NULL);
-            [_pixelBufferLock lock];
-            CVPixelBufferPoolCreatePixelBuffer (kCFAllocatorDefault, _pixelBufferAdaptor.pixelBufferPool, &pixelBuffer);
-            [_pixelBufferLock unlock];
-            NSParameterAssert(pixelBuffer != NULL);
-        });
-        
-        //unlock pixel buffer data
-        CVPixelBufferLockBaseAddress(pixelBuffer, 0);
-        void *pixelData = CVPixelBufferGetBaseAddress(pixelBuffer);
-        NSParameterAssert(pixelData != NULL);
-        
-        //copy over raw image data and free
-        memcpy(pixelData, [rawDataObj bytes], totalBytes);
-        //free(rawData);
-        @synchronized(buffers) {
-            [buffers addObject:rawDataObj];
-        }
-        
-        //unlock pixel buffer data
-        CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
-        
-        dispatch_async(_video_queue, ^{
-            // Wait until AVAssetWriterInput is ready
-            while(!_videoWriterInput.readyForMoreMediaData)
-                usleep(1000);
-            
-            // Lock from other threads
-            [_pixelBufferLock lock];
-            // Add the new frame to the video
-            [_pixelBufferAdaptor appendPixelBuffer:pixelBuffer withPresentationTime:frameTime];
-            
-            // Unlock
-            //CVPixelBufferRelease(pixelBuffer);
-            [_pixelBufferLock unlock];
-        });
-    });
-}
-
-#pragma mark - Encoding
-- (void)setupVideoContext
-{
-    // Get the screen rect and scale
-    CGRect screenRect = [UIScreen mainScreen].bounds;
-    float scale = [UIScreen mainScreen].scale;
-    
-    // setup the width and height of the framebuffer for the device
-    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
-        // iPhone frame buffer is Portrait
-        _width = screenRect.size.width * scale;
-        _height = screenRect.size.height * scale;
-    } else {
-        // iPad frame buffer is Landscape
-        _width = screenRect.size.height * scale;
-        _height = screenRect.size.width * scale;
-    }
-    
-    // Get the output file path
-    NSString *outPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents/video.mp4"];
-    if (![[[NSUserDefaults standardUserDefaults] objectForKey:@"record"] boolValue]){
-        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat:@"MM:dd:yyyy h:mm:ss a"];
-        NSString *date = [dateFormatter stringFromDate:[NSDate date]];
-        NSString *outName = [NSString stringWithFormat:@"Documents/%@.mp4",date];
-        outPath = [NSHomeDirectory() stringByAppendingPathComponent:outName];
-        [dateFormatter release];
-    }
-    
-    NSError *error = nil;
-    
-    // Setup AVAssetWriter with the output path
-    _videoWriter = [[AVAssetWriter alloc] initWithURL:[NSURL fileURLWithPath:outPath]
-                                             fileType:AVFileTypeMPEG4
-                                                error:&error];
-    // check for errors
-    if(error)
-    {
-        NSLog(@"error: %@", error);
-        return;
-    }
-    
-    // Makes sure AVAssetWriter is valid (check check check)
-    NSParameterAssert(_videoWriter);
-    
-    // Setup AverageBitRate, FrameInterval, and ProfileLevel (Compression Properties)
-    NSMutableDictionary * compressionProperties = [NSMutableDictionary dictionary];
-    [compressionProperties setObject: [NSNumber numberWithInt: _kbps * 1000] forKey: AVVideoAverageBitRateKey];
-    [compressionProperties setObject: [NSNumber numberWithInt: _fps] forKey: AVVideoMaxKeyFrameIntervalKey];
-    [compressionProperties setObject: AVVideoProfileLevelH264Main41 forKey: AVVideoProfileLevelKey];
-    
-    // Setup output settings, Codec, Width, Height, Compression
-    int videowidth = _width;
-    int videoheight = _height;
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:@"vidsize"]) {
-        if (![[[NSUserDefaults standardUserDefaults] objectForKey:@"vidsize"] boolValue]){
-            videowidth /= 2; //If it's set to half-size, divide both by 2.
-            videoheight /= 2;
-        }
-    }
-    NSMutableDictionary *outputSettings = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                           AVVideoCodecH264, AVVideoCodecKey,
-                                           [NSNumber numberWithInt:videowidth], AVVideoWidthKey,
-                                           [NSNumber numberWithInt:videoheight], AVVideoHeightKey,
-                                           compressionProperties, AVVideoCompressionPropertiesKey,
-                                           nil];
-    
-    NSParameterAssert([_videoWriter canApplyOutputSettings:outputSettings forMediaType:AVMediaTypeVideo]);
-    
-    // Get a AVAssetWriterInput
-    // Add the output settings
-    _videoWriterInput = [[AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
-                                                            outputSettings:outputSettings] retain];
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:@"vidorientation"]) {
-        float radians = [[[NSUserDefaults standardUserDefaults] objectForKey:@"vidorientation"] floatValue];
-        _videoWriterInput.transform = CGAffineTransformMakeRotation(radians);
-    }
-    // Check if AVAssetWriter will take an AVAssetWriterInput
-    NSParameterAssert(_videoWriterInput);
-    NSParameterAssert([_videoWriter canAddInput:_videoWriterInput]);
-    [_videoWriter addInput:_videoWriterInput];
-    
-    // Setup buffer attributes, PixelFormatType, PixelBufferWidth, PixelBufferHeight, PixelBufferMemoryAlocator
-    NSDictionary *bufferAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
-                                      [NSNumber numberWithInt:kCVPixelFormatType_32BGRA], kCVPixelBufferPixelFormatTypeKey,
-                                      [NSNumber numberWithInt:_width], kCVPixelBufferWidthKey,
-                                      [NSNumber numberWithInt:_height], kCVPixelBufferHeightKey,
-                                      kCFAllocatorDefault, kCVPixelBufferMemoryAllocatorKey,
-                                      nil];
-    
-    // Get AVAssetWriterInputPixelBufferAdaptor with the buffer attributes
-    _pixelBufferAdaptor = [AVAssetWriterInputPixelBufferAdaptor assetWriterInputPixelBufferAdaptorWithAssetWriterInput:_videoWriterInput
-                                                                                           sourcePixelBufferAttributes:bufferAttributes];
-    [_pixelBufferAdaptor retain];
-    
-    //FPS
-    _videoWriterInput.mediaTimeScale = _fps;
-    _videoWriter.movieTimeScale = _fps;
-    
-    //Start a session:
-    [_videoWriterInput setExpectsMediaDataInRealTime:YES];
-    [_videoWriter startWriting];
-    [_videoWriter startSessionAtSourceTime:kCMTimeZero];
-    
-    NSParameterAssert(_pixelBufferAdaptor.pixelBufferPool != NULL);
     
 }
 
-
--(void)finishEncoding
+- (void)screenRecorder:(CSScreenRecorder *)recorder audioRecorderSetupFailedWithError:(NSError *)error
 {
-    // Tell the AVAssetWriterInput were done appending buffers
-    [_videoWriterInput markAsFinished];
     
-    // Tell the AVAssetWriter to finish and close the file
-    [_videoWriter finishWriting];
-    
-    // Make objects go away
-    [_videoWriter release];
-    [_videoWriterInput release];
-    [_pixelBufferAdaptor release];
-    _videoWriter = nil;
-    _videoWriterInput = nil;
-    _pixelBufferAdaptor = nil;
 }
 
+- (void)screenRecorder:(CSScreenRecorder *)recorder audioSessionSetupFailedWithError:(NSError *)error
+{
+    
+}
 
 @end

--- a/RecordMyScreen/CSRecordViewController.xib
+++ b/RecordMyScreen/CSRecordViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
-		<int key="IBDocument.SystemTarget">1296</int>
-		<string key="IBDocument.SystemVersion">12C54</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2549</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">11G63</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1138.51</string>
+		<string key="IBDocument.HIToolboxVersion">569.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1498</string>
+			<string key="NS.object.0">2083</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>IBProxyObject</string>
@@ -43,7 +43,6 @@
 						<int key="NSvFlags">290</int>
 						<string key="NSFrameSize">{320, 44}</string>
 						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="340183433"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -61,8 +60,6 @@
 						<int key="NSvFlags">290</int>
 						<string key="NSFrame">{{0, 44}, {320, 104}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -76,7 +73,6 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{85, 52}, {150, 39}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="912478249"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -110,7 +106,6 @@
 						<int key="NSvFlags">274</int>
 						<string key="NSFrame">{{0, 142}, {320, 269}}</string>
 						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<int key="IBUIContentMode">4</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
@@ -123,7 +118,6 @@
 				</array>
 				<string key="NSFrame">{{0, 20}, {320, 411}}</string>
 				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="1021970584"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
@@ -274,7 +268,7 @@
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1296" key="NS.object.0"/>
+			<real value="1552" key="NS.object.0"/>
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
@@ -282,6 +276,6 @@
 			<string key="lens.png">{159, 160}</string>
 			<string key="side_top.png">{319, 63}</string>
 		</dictionary>
-		<string key="IBCocoaTouchPluginVersion">1498</string>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/RecordMyScreen/CSScreenRecorder.h
+++ b/RecordMyScreen/CSScreenRecorder.h
@@ -1,0 +1,44 @@
+//
+//  CSScreenRecorder.h
+//  RecordMyScreen
+//
+//  Created by Aditya KD on 02/04/13.
+//  Copyright (c) 2013 CoolStar Organization. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+@protocol CSScreenRecorderDelegate;
+
+
+@interface CSScreenRecorder : NSObject <AVAudioRecorderDelegate>
+
+// All these properties must be set before -startRecordingScreen is called, or defaults will be used.
+
+// the path where the video/audio is saved whilst being recorded.
+@property(nonatomic, copy) NSString *videoOutPath;
+@property(nonatomic, copy) NSString *audioOutPath;
+
+@property(nonatomic, copy) NSNumber *audioSampleRate;
+@property(nonatomic, copy) NSNumber *numberOfAudioChannels;
+
+@property(nonatomic, assign) id<CSScreenRecorderDelegate> delegate;
+
+- (void)startRecordingScreen;
+- (void)stopRecordingScreen;
+
+@end
+
+@protocol CSScreenRecorderDelegate <NSObject>
+@optional
+- (void)screenRecorderDidStartRecording:(CSScreenRecorder *)recorder;
+- (void)screenRecorderDidStopRecording:(CSScreenRecorder *)recorder;
+// Called every second.
+- (void)screenRecorder:(CSScreenRecorder *)recorder recordingTimeChanged:(NSTimeInterval)recordingTime; // time in seconds since start of capture
+
+- (void)screenRecorder:(CSScreenRecorder *)recorder videoContextSetupFailedWithError:(NSError *)error;
+- (void)screenRecorder:(CSScreenRecorder *)recorder audioSessionSetupFailedWithError:(NSError *)error;
+- (void)screenRecorder:(CSScreenRecorder *)recorder audioRecorderSetupFailedWithError:(NSError *)error;
+
+@end

--- a/RecordMyScreen/CSScreenRecorder.m
+++ b/RecordMyScreen/CSScreenRecorder.m
@@ -1,0 +1,498 @@
+//
+//  CSScreenRecorder.m
+//  RecordMyScreen
+//
+//  Created by Aditya KD on 02/04/13.
+//  Copyright (c) 2013 CoolStar Organization. All rights reserved.
+//
+
+#import "CSScreenRecorder.h"
+
+#import <IOMobileFrameBuffer.h>
+#import <CoreVideo/CVPixelBuffer.h>
+#import <QuartzCore/QuartzCore.h>
+
+#include <IOSurface.h>
+#include <sys/time.h>
+
+void CARenderServerRenderDisplay(kern_return_t a, CFStringRef b, IOSurfaceRef surface, int x, int y);
+
+@interface CSScreenRecorder ()
+{
+@private
+    BOOL                _isRecording;
+    int                 _kbps;
+    int                 _fps;
+    
+    //surface
+    IOSurfaceRef        _surface;
+    int                 _bytesPerRow;
+    int                 _width;
+    int                 _height;
+    
+    dispatch_queue_t    _videoQueue;
+    
+    NSLock             *_pixelBufferLock;
+    NSTimer            *_recordingTimer;
+    NSDate             *_recordStartDate;
+    
+    AVAudioRecorder    *_audioRecorder;
+    AVAssetWriter      *_videoWriter;
+    AVAssetWriterInput *_videoWriterInput;
+    AVAssetWriterInputPixelBufferAdaptor *_pixelBufferAdaptor;
+}
+
+- (void)_setupVideoContext;
+- (void)_setupAudio;
+- (void)_setupVideoAndStartRecording;
+- (void)_captureShot:(CMTime)frameTime;
+- (IOSurfaceRef)_createScreenSurface;
+- (void)_finishEncoding;
+
+- (void)_sendDelegateTimeUpdate:(NSTimer *)timer;
+
+@end
+
+@implementation CSScreenRecorder
+
+- (instancetype)init
+{
+    if ((self = [super init])) {
+        _pixelBufferLock = [NSLock new];
+        
+        //video queue
+        _videoQueue = dispatch_queue_create("video_queue", DISPATCH_QUEUE_SERIAL);
+        //frame rate
+        _fps = 24;
+        //encoding kbps
+        _kbps = 5000;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    CFRelease(_surface);
+    _surface = NULL;
+    
+    dispatch_release(_videoQueue);
+    _videoQueue = NULL;
+    
+    [_pixelBufferLock release];
+    _pixelBufferLock = nil;
+    
+    [_videoOutPath release];
+    _videoOutPath = nil;
+    
+    _recordingTimer = nil;
+    // These are released when capture stops, etc, but what if?
+    // You don't want to leak memory!
+    [_recordStartDate release];
+    _recordStartDate = nil;
+    
+    [_audioRecorder release];
+    _audioRecorder = nil;
+    
+    [_videoWriter release];
+    _videoWriter = nil;
+    
+    [_videoWriterInput release];
+    _videoWriterInput = nil;
+    
+    [_pixelBufferAdaptor release];
+    _pixelBufferAdaptor = nil;
+    
+    [super dealloc];
+}
+
+- (void)startRecordingScreen
+{
+    // if the AVAssetWriter is NOT valid, setup video context
+    if(!_videoWriter)
+        [self _setupVideoContext]; // this must be done before _setupVideoAndStartRecording
+    _recordStartDate = [[NSDate date] retain];
+    
+    [self _setupAudio];
+    [self _setupVideoAndStartRecording];
+}
+
+- (void)stopRecordingScreen
+{
+    // Set the flag to stop recording
+    _isRecording = NO;
+    
+    // Invalidate the recording time
+    [_recordingTimer invalidate];
+    _recordingTimer = nil;
+    
+    
+    // Stop the audio recording
+    [_audioRecorder stop];
+    [_audioRecorder release];
+    _audioRecorder = nil;
+    
+    [_recordStartDate release];
+    _recordStartDate = nil;
+    
+    if ([self.delegate respondsToSelector:@selector(screenRecorderDidStopRecording:)]) {
+        [self.delegate screenRecorderDidStopRecording:self];
+    }
+}
+
+- (void)_setupAudio
+{
+    // Setup to be able to record global sounds (preexisting app sounds)
+	NSError *sessionError = nil;
+    if ([[AVAudioSession sharedInstance] respondsToSelector:@selector(setCategory:withOptions:error:)])
+        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord withOptions:AVAudioSessionCategoryOptionDuckOthers error:&sessionError];
+    else
+        [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayAndRecord error:&sessionError];
+    
+    // Set the audio session to be active
+	[[AVAudioSession sharedInstance] setActive:YES error:&sessionError];
+    
+    if (sessionError && [self.delegate respondsToSelector:@selector(screenRecorder:audioSessionSetupFailedWithError:)]) {
+        [self.delegate screenRecorder:self audioSessionSetupFailedWithError:sessionError];
+        return;
+    }
+    
+    // Set the number of audio channels, using defaults if necessary.
+    NSNumber *audioChannels = (self.numberOfAudioChannels ? self.numberOfAudioChannels : [NSNumber numberWithInt:2]);
+    NSNumber *sampleRate    = (self.audioSampleRate       ? self.audioSampleRate       : [NSNumber numberWithFloat:44100.f]);
+    
+    NSDictionary *audioSettings = @{
+                                    AVNumberOfChannelsKey : (audioChannels ? audioChannels : ([NSNumber numberWithInt:2])),
+                                    AVSampleRateKey       : (sampleRate    ? sampleRate    : ([NSNumber numberWithFloat:44100.0f]))
+                                    };
+    
+    
+    // Initialize the audio recorder
+    // Set output path of the audio file
+    NSError *error = nil;
+    NSAssert((self.audioOutPath != nil), @"Audio out path cannot be nil!");
+    _audioRecorder = [[AVAudioRecorder alloc] initWithURL:[NSURL fileURLWithPath:self.audioOutPath] settings:audioSettings error:&error];
+    if (error && [self.delegate respondsToSelector:@selector(screenRecorder:audioRecorderSetupFailedWithError:)]) {
+        // Let the delegate know that shit has happened.
+        [self.delegate screenRecorder:self audioRecorderSetupFailedWithError:error];
+        
+        [_audioRecorder release];
+        _audioRecorder = nil;
+        
+        return;
+    }
+    
+    [_audioRecorder setDelegate:self];
+    [_audioRecorder prepareToRecord];
+    
+    // Start recording :P
+    [_audioRecorder record];
+}
+
+- (void)_setupVideoAndStartRecording
+{
+    // Set timer to notify the delegate of time changes every second
+    _recordingTimer = [NSTimer scheduledTimerWithTimeInterval:1
+                                                       target:self
+                                                     selector:@selector(_sendDelegateTimeUpdate:)
+                                                     userInfo:nil
+                                                      repeats:YES];
+    
+    _isRecording = YES;
+
+    //capture loop (In another thread)
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        int targetFPS = _fps;
+        int msBeforeNextCapture = 1000 / targetFPS;
+        
+        struct timeval lastCapture, currentTime, startTime;
+        lastCapture.tv_sec = 0;
+        lastCapture.tv_usec = 0;
+        
+        //recording start time
+        gettimeofday(&startTime, NULL);
+        startTime.tv_usec /= 1000;
+        
+        int lastFrame = -1;
+        while(_isRecording)
+        {
+            //time passed since last capture
+            gettimeofday(&currentTime, NULL);
+            
+            //convert to milliseconds to avoid overflows
+            currentTime.tv_usec /= 1000;
+            
+            unsigned long long diff = (currentTime.tv_usec + (1000 * currentTime.tv_sec) ) - (lastCapture.tv_usec + (1000 * lastCapture.tv_sec) );
+            
+            // if enough time has passed, capture another shot
+            if(diff >= msBeforeNextCapture)
+            {
+                //time since start
+                long int msSinceStart = (currentTime.tv_usec + (1000 * currentTime.tv_sec) ) - (startTime.tv_usec + (1000 * startTime.tv_sec) );
+                
+                // Generate the frame number
+                int frameNumber = msSinceStart / msBeforeNextCapture;
+                CMTime presentTime;
+                presentTime = CMTimeMake(frameNumber, targetFPS);
+                
+                // Frame number cannot be last frames number :P
+                NSParameterAssert(frameNumber != lastFrame);
+                lastFrame = frameNumber;
+                
+                // Capture next shot and repeat
+                [self _captureShot:presentTime];
+                lastCapture = currentTime;
+            }
+        }
+        
+        // finish encoding, using the video_queue thread
+        dispatch_async(_videoQueue, ^{
+            [self _finishEncoding];
+        });
+        
+    });
+}
+
+- (void)_captureShot:(CMTime)frameTime
+{
+    // Create an IOSurfaceRef if one does not exist
+    if(!_surface) {
+        _surface = [self _createScreenSurface];
+    }
+    
+    // Lock the surface from other threads
+    static NSMutableArray * buffers = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        buffers = [[NSMutableArray alloc] init];
+    });
+    
+    IOSurfaceLock(_surface, 0, nil);
+    // Take currently displayed image from the LCD
+    CARenderServerRenderDisplay(0, CFSTR("LCD"), _surface, 0, 0);
+    // Unlock the surface
+    IOSurfaceUnlock(_surface, 0, 0);
+    
+    // Make a raw memory copy of the surface
+    void *baseAddr = IOSurfaceGetBaseAddress(_surface);
+    int totalBytes = _bytesPerRow * _height;
+    
+    //void *rawData = malloc(totalBytes);
+    //memcpy(rawData, baseAddr, totalBytes);
+    NSMutableData * rawDataObj = nil;
+    if (buffers.count == 0)
+        rawDataObj = [[NSMutableData dataWithBytes:baseAddr length:totalBytes] retain];
+    else @synchronized(buffers) {
+        rawDataObj = [buffers lastObject];
+        memcpy((void *)[rawDataObj bytes], baseAddr, totalBytes);
+        //[rawDataObj replaceBytesInRange:NSMakeRange(0, rawDataObj.length) withBytes:baseAddr length:totalBytes];
+        [buffers removeLastObject];
+    }
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        
+        if(!_pixelBufferAdaptor.pixelBufferPool){
+            NSLog(@"skipping frame: %lld", frameTime.value);
+            //free(rawData);
+            @synchronized(buffers) {
+                //[buffers addObject:rawDataObj];
+            }
+            return;
+        }
+        
+        static CVPixelBufferRef pixelBuffer = NULL;
+        
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            NSParameterAssert(_pixelBufferAdaptor.pixelBufferPool != NULL);
+            [_pixelBufferLock lock];
+            CVPixelBufferPoolCreatePixelBuffer (kCFAllocatorDefault, _pixelBufferAdaptor.pixelBufferPool, &pixelBuffer);
+            [_pixelBufferLock unlock];
+            NSParameterAssert(pixelBuffer != NULL);
+        });
+        
+        //unlock pixel buffer data
+        CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+        void *pixelData = CVPixelBufferGetBaseAddress(pixelBuffer);
+        NSParameterAssert(pixelData != NULL);
+        
+        //copy over raw image data and free
+        memcpy(pixelData, [rawDataObj bytes], totalBytes);
+        //free(rawData);
+        @synchronized(buffers) {
+            [buffers addObject:rawDataObj];
+        }
+        
+        //unlock pixel buffer data
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
+        
+        dispatch_async(_videoQueue, ^{
+            // Wait until AVAssetWriterInput is ready
+            while(!_videoWriterInput.readyForMoreMediaData)
+                usleep(1000);
+            
+            // Lock from other threads
+            [_pixelBufferLock lock];
+            // Add the new frame to the video
+            [_pixelBufferAdaptor appendPixelBuffer:pixelBuffer withPresentationTime:frameTime];
+            
+            // Unlock
+            //CVPixelBufferRelease(pixelBuffer);
+            [_pixelBufferLock unlock];
+        });
+    });
+}
+
+- (IOSurfaceRef)_createScreenSurface
+{
+    // Pixel format for Alpha Red Green Blue
+    unsigned pixelFormat = 0x42475241;//'ARGB';
+    
+    // 4 Bytes per pixel
+    int bytesPerElement = 4;
+    
+    // Bytes per row
+    _bytesPerRow = (bytesPerElement * _width);
+    
+    // Properties include: SurfaceIsGlobal, BytesPerElement, BytesPerRow, SurfaceWidth, SurfaceHeight, PixelFormat, SurfaceAllocSize (space for the entire surface)
+    NSDictionary *properties = [NSDictionary dictionaryWithObjectsAndKeys:
+                                [NSNumber numberWithBool:YES], kIOSurfaceIsGlobal,
+                                [NSNumber numberWithInt:bytesPerElement], kIOSurfaceBytesPerElement,
+                                [NSNumber numberWithInt:_bytesPerRow], kIOSurfaceBytesPerRow,
+                                [NSNumber numberWithInt:_width], kIOSurfaceWidth,
+                                [NSNumber numberWithInt:_height], kIOSurfaceHeight,
+                                [NSNumber numberWithUnsignedInt:pixelFormat], kIOSurfacePixelFormat,
+                                [NSNumber numberWithInt:_bytesPerRow * _height], kIOSurfaceAllocSize,
+                                nil];
+    
+    // This is the current surface
+    return IOSurfaceCreate((CFDictionaryRef)properties);
+}
+
+#pragma mark - Encoding
+- (void)_setupVideoContext
+{
+    // Get the screen rect and scale
+    CGRect screenRect = [UIScreen mainScreen].bounds;
+    float scale = [UIScreen mainScreen].scale;
+    
+    // setup the width and height of the framebuffer for the device
+    if ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {
+        // iPhone frame buffer is Portrait
+        _width = screenRect.size.width * scale;
+        _height = screenRect.size.height * scale;
+    } else {
+        // iPad frame buffer is Landscape
+        _width = screenRect.size.height * scale;
+        _height = screenRect.size.width * scale;
+    }
+    
+    NSAssert((self.videoOutPath != nil) , @"A valid videoOutPath must be set before the recording starts!");
+    
+    NSError *error = nil;
+    
+    // Setup AVAssetWriter with the output path
+    _videoWriter = [[AVAssetWriter alloc] initWithURL:[NSURL fileURLWithPath:self.videoOutPath]
+                                             fileType:AVFileTypeMPEG4
+                                                error:&error];
+    // check for errors
+    if(error) {
+        if ([self.delegate respondsToSelector:@selector(screenRecorder:videoContextSetupFailedWithError:)]) {
+            [self.delegate screenRecorder:self videoContextSetupFailedWithError:error];
+        }
+    }
+    
+    // Makes sure AVAssetWriter is valid (check check check)
+    NSParameterAssert(_videoWriter);
+    
+    // Setup AverageBitRate, FrameInterval, and ProfileLevel (Compression Properties)
+    NSMutableDictionary * compressionProperties = [NSMutableDictionary dictionary];
+    [compressionProperties setObject: [NSNumber numberWithInt: _kbps * 1000] forKey: AVVideoAverageBitRateKey];
+    [compressionProperties setObject: [NSNumber numberWithInt: _fps] forKey: AVVideoMaxKeyFrameIntervalKey];
+    [compressionProperties setObject: AVVideoProfileLevelH264Main41 forKey: AVVideoProfileLevelKey];
+    
+    // Setup output settings, Codec, Width, Height, Compression
+    int videowidth = _width;
+    int videoheight = _height;
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:@"vidsize"]) {
+        if (![[[NSUserDefaults standardUserDefaults] objectForKey:@"vidsize"] boolValue]){
+            videowidth /= 2; //If it's set to half-size, divide both by 2.
+            videoheight /= 2;
+        }
+    }
+    NSMutableDictionary *outputSettings = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                           AVVideoCodecH264, AVVideoCodecKey,
+                                           [NSNumber numberWithInt:videowidth], AVVideoWidthKey,
+                                           [NSNumber numberWithInt:videoheight], AVVideoHeightKey,
+                                           compressionProperties, AVVideoCompressionPropertiesKey,
+                                           nil];
+    
+    NSParameterAssert([_videoWriter canApplyOutputSettings:outputSettings forMediaType:AVMediaTypeVideo]);
+    
+    // Get a AVAssetWriterInput
+    // Add the output settings
+    _videoWriterInput = [[AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
+                                                            outputSettings:outputSettings] retain];
+    if ([[NSUserDefaults standardUserDefaults] objectForKey:@"vidorientation"]) {
+        float radians = [[[NSUserDefaults standardUserDefaults] objectForKey:@"vidorientation"] floatValue];
+        _videoWriterInput.transform = CGAffineTransformMakeRotation(radians);
+    }
+    // Check if AVAssetWriter will take an AVAssetWriterInput
+    NSParameterAssert(_videoWriterInput);
+    NSParameterAssert([_videoWriter canAddInput:_videoWriterInput]);
+    [_videoWriter addInput:_videoWriterInput];
+    
+    // Setup buffer attributes, PixelFormatType, PixelBufferWidth, PixelBufferHeight, PixelBufferMemoryAlocator
+    NSDictionary *bufferAttributes = [NSDictionary dictionaryWithObjectsAndKeys:
+                                      [NSNumber numberWithInt:kCVPixelFormatType_32BGRA], kCVPixelBufferPixelFormatTypeKey,
+                                      [NSNumber numberWithInt:_width], kCVPixelBufferWidthKey,
+                                      [NSNumber numberWithInt:_height], kCVPixelBufferHeightKey,
+                                      kCFAllocatorDefault, kCVPixelBufferMemoryAllocatorKey,
+                                      nil];
+    
+    // Get AVAssetWriterInputPixelBufferAdaptor with the buffer attributes
+    _pixelBufferAdaptor = [AVAssetWriterInputPixelBufferAdaptor assetWriterInputPixelBufferAdaptorWithAssetWriterInput:_videoWriterInput
+                                                                                           sourcePixelBufferAttributes:bufferAttributes];
+    [_pixelBufferAdaptor retain];
+    
+    //FPS
+    _videoWriterInput.mediaTimeScale = _fps;
+    _videoWriter.movieTimeScale = _fps;
+    
+    //Start a session:
+    [_videoWriterInput setExpectsMediaDataInRealTime:YES];
+    [_videoWriter startWriting];
+    [_videoWriter startSessionAtSourceTime:kCMTimeZero];
+    
+    NSParameterAssert(_pixelBufferAdaptor.pixelBufferPool != NULL);
+    
+}
+
+
+- (void)_finishEncoding
+{
+    // Tell the AVAssetWriterInput were done appending buffers
+    [_videoWriterInput markAsFinished];
+    
+    // Tell the AVAssetWriter to finish and close the file
+    [_videoWriter finishWriting];
+    
+    // Make objects go away
+    [_videoWriter release];
+    [_videoWriterInput release];
+    [_pixelBufferAdaptor release];
+    _videoWriter = nil;
+    _videoWriterInput = nil;
+    _pixelBufferAdaptor = nil;
+}
+
+
+#pragma mark - Delegate Stuff
+- (void)_sendDelegateTimeUpdate:(NSTimer *)timer
+{
+    if ([self.delegate respondsToSelector:@selector(screenRecorder:recordingTimeChanged:)]) {
+        NSTimeInterval timeInterval = [[NSDate date] timeIntervalSinceDate:_recordStartDate];
+        [self.delegate screenRecorder:self recordingTimeChanged:timeInterval];
+    }
+}
+
+@end


### PR DESCRIPTION
This cleans up the view controller's implementation by a large margin, and brings the code more in line with the OOP/MVC model.
