### PR TITLE
Fixes Audio/Video Sync Issue

### DIFF
--- a/RecordMyScreen/CSScreenRecorder.m
+++ b/RecordMyScreen/CSScreenRecorder.m
@@ -513,6 +513,7 @@ void CARenderServerRenderDisplay(kern_return_t a, CFStringRef b, IOSurfaceRef su
 	if (assetVideoTrack != nil) {
 		AVMutableCompositionTrack *compositionVideoTrack = [mixComposition addMutableTrackWithMediaType:AVMediaTypeVideo preferredTrackID:kCMPersistentTrackID_Invalid];
 		[compositionVideoTrack insertTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration) ofTrack:assetVideoTrack atTime:kCMTimeZero error:nil];
+		if (assetAudioTrack != nil) [compositionVideoTrack scaleTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration) toDuration:audioAsset.duration];
 		[compositionVideoTrack setPreferredTransform:CGAffineTransformMakeRotation(degreesToRadians(degrees))];
 	}
 	


### PR DESCRIPTION
Based on the comment on an issue: 
 (Quote)"jallens commented 4 days ago
i fix it.

in file : CSScreenRecorder.m line : 516
add:
[compositionVideoTrack scaleTimeRange:CMTimeRangeMake(kCMTimeZero, videoAsset.duration) toDuration:audioAsset.duration]; " (End Quote)

This was tested and successful by nicolasgomollon on his version of RecordMyScreen! (RecordScreen)
